### PR TITLE
remove symlinking .env

### DIFF
--- a/dotenv/recipes/default.rb
+++ b/dotenv/recipes/default.rb
@@ -4,8 +4,4 @@ node[:deploy].each do |application, deploy|
     deploy deploy
     env node[:deploy][application.to_sym][:env]
   end
-
-  link "#{deploy[:deploy_to]}/current/.env" do
-    to "#{deploy[:deploy_to]}/shared/config/dotenv"
-  end
 end


### PR DESCRIPTION
## Problem
- OpsWorks fails deployment when new instance is added.
- changing .env file via custom JSON doesn't affect the next deployment
### Why?

When new instance is added, OpsWorks do initial setup and deploy with the following order:
1. Trigger Setup event
   1. execute built-in setup recipes
   2. execute custom setup recipes
2. Trigger Deploy event
   1.  execute built-in deploy recipes
      1. checkout code to deploy
      2. symlink current directory
      3. restart unicorn
   2. execute custom deploy recipes
3. Trigger Configure event

Since current master branch of this repository creates `.env` symlink in `current` directory, `dotenv` recipe requires that `current` directory exists. because of that, we have to put this recipe in custom deploy recipes.
But at the time `dotenv` recipe is executed, as the above sequences explains, unicorn already start so putting `.env` file doesn't affect the running unicorn process.
That's why opsworks fails when new instance is added because at the time OpsWorks run unicorn, `.env` file doesn't exists in `current` and `shared` directory. 
## Solution
1. Remove symlinking from this `dotenv` recipe(this is what this pullrequest does)
2. Move(or add) `dotenv` recipe to Setup
3. Add the following `symlink_before_migrate` setting to OpsWorks custom JSON

```
{
  "deploy":{
    "app_name":{
      "symlink_before_migrate":{
        "config/dotenv" : ".env"
      },
      ...
    }
  }
}
```
