### PR TITLE
Ensure deploy directory exists

### DIFF
--- a/dotenv/recipes/default.rb
+++ b/dotenv/recipes/default.rb
@@ -1,4 +1,10 @@
 node[:deploy].each do |application, deploy|
+  opsworks_deploy_dir do
+    user deploy[:user]
+    group deploy[:group]
+    path deploy[:deploy_to]
+  end
+
   dotenv_template do
     application application
     deploy deploy


### PR DESCRIPTION
deploy directory must be exist before running dotenv recipe.
For rails app layer, `unicorn::rails` recipe does this. see https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/unicorn/recipes/rails.rb#L19

But for delayed_job, there're no existing recipe that creates deploy directory in setup recipes. So we can't use dotenv recipe in setup phase without this pull request.

Actually I haven't test that this change works correctly...
