### PR TITLE
add deploy dependency

### DIFF
--- a/dotenv/metadata.rb
+++ b/dotenv/metadata.rb
@@ -5,3 +5,4 @@ license          'All rights reserved'
 description      'Creates a .env file from custom JSON in Opsworks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
+depends          'deploy'


### PR DESCRIPTION
As I said at #4, dotenv recipe should execute before OpsWorks's deploy event. but with this approach dotenv recipe doesn't run when we just trigger deploy event. silly mistake, sorry.

The problem is there's no way to run dotenv recipe before built-in deploy recipes on each deploy trigger.
So I decided to run dotenv recipe manually by "Run Command" ->  "Execute Recipes"

When I ran the "Execute Recipes" it fails because `opsworks_deploy_dir` doesn't exist.
I checked some articles about OpsWorks and I think maybe this PR works.

We should have OpsWorks local test environment...
