### PR TITLE
Add `pool_size` for adding multiple delayed_job workers

### DIFF
--- a/delayed_job/attributes/default.rb
+++ b/delayed_job/attributes/default.rb
@@ -1,4 +1,16 @@
+include_attribute "deploy"
+
 default[:delayed_job][:timeout] = 60
 default[:delayed_job][:bin] = "bin/delayed_job"
 default[:delayed_job][:suffix] = ""
 default[:delayed_job][:options] = ""
+
+node[:deploy].each do |application, deploy|
+  if deploy[:delayed_job][:pool_size]
+    default[:delayed_job][:workers] = deploy[:delayed_job][:pool_size].times.map{ {} }
+  end
+
+  if deploy[:delayed_job][:workers]
+    default[:delayed_job][:workers] = deploy[:delayed_job][:workers]
+  end
+end


### PR DESCRIPTION
This pull request allows you to specify a `pool_size` for the worker count. I've also added a `workers` key for manually configuring options for each worker.

For example, setting a `pool_size` would setup workers: "delayed_job.1, delayed_job.2, etc." under monit

```
"delayed_job": {
    "pool_size": 6
}
```

You can also manually configure workers by omitting pool_size and using the `workers` key

```
"delayed_job": {
    "workers": [
        {
            "identifier": "regular",
            "timeout": 60
        },
        {
            "identifier": "priority",
            "options": "--min-priority 10",
            "timeout": 30
        }
    ]
}
```
