### PR TITLE
Add Berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+cookbook 'squid'


### PR DESCRIPTION
The Berksfile includes squid(outbound proxy)

To use it on OpsWorks, you need to

- Enable "Manage Berkshelf" in opsworks stack setting
- Add `squid::default` recipe to layer recipes
- Add the following Custom JSON

```
{
  "opsworks": {
    "squid": {
      // your customization
      // "port": 8080
    }
  }
}