### PR TITLE
Overrides default database.yml.erb for charset and collation options

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -1,0 +1,19 @@
+<% (['development', 'production'] + [@environment]).uniq.each do |env| -%>
+<%= env %>:
+  adapter: <%= @database[:adapter].to_s.inspect %>
+  database: <%= @database[:database].to_s.inspect %>
+  encoding: <%= (@database[:encoding] || 'utf8').to_s.inspect %>
+  host: <%= (@database[:host] || 'localhost').to_s.inspect %>
+  username: <%= @database[:username].to_s.inspect %>
+  password: <%= @database[:password].to_s.inspect %>
+  reconnect: <%= @database[:reconnect] ? 'true' : 'false' %>
+  charset: <%= @database[:charset].to_s.inspect %>
+  collation: <%= @database[:collation].to_s.inspect %>
+<% if @database[:pool] -%>
+  pool: <%= @database[:pool].to_i.inspect %>
+<% end -%>
+<% if @database[:port] -%>
+  port: <%= @database[:port].to_i.inspect %>
+<% end -%>
+
+<% end %>


### PR DESCRIPTION
I added charset and collation options to [default database.yml.erb](https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/rails/templates/default/database.yml.erb).
